### PR TITLE
Check if lat and log are functions

### DIFF
--- a/src/geocodeAnyone.js
+++ b/src/geocodeAnyone.js
@@ -47,9 +47,14 @@
 		},
 		
 		askAddressSuccess:function(position){
-		
-			var lat = (position.coords!=null)?position.coords.latitude:position.G;
-		 	var lng = (position.coords!=null)?position.coords.longitude:position.K;
+			if (typeof position.lat == 'function' && typeof position.lng == 'function' ) {
+				var lat = position.lat();
+				var lng = position.lng();
+			} else {
+				var lat = (position.coords!=null)?position.coords.latitude:position.G;
+				var lng = (position.coords!=null)?position.coords.longitude:position.K;
+			}
+			
 		  	geocodeAnyone.fullAddress = geocodeAnyone.getAddressFromLatLng(lat, lng);
 		  	return geocodeAnyone.fullAddress;
 		  	


### PR DESCRIPTION
`position.lat` and `position.lng` passed to the askAddressSuccess method usually are function, so the relative values can be accessed by calling `lat` and `lng` as functions. I added the two assignments inside an `if` just to avoid the possibility of braking things.
